### PR TITLE
update link for vegas plugin kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Sample OFX plugins from the Sony Vegas SDK, ported to OSX and Linux
 
 These plugins were adapted to compile and work on Linux and OSX.
 
-The Sony Vegas SDK has to be downloaded separately, due to its license:
-From the [Sony Development Kits Download Page](http://www.sonycreativesoftware.com/download/devkits) 
-download "Video Plug-In Development Kit (OFX)".
+The Sony Vegas SDK has to be downloaded separately, due to its license, from [here](http://download.sonymediasoftware.com/dev/video_plugin_kit_ofx.zip).
 The file, named `video_plugin_kit_OFX.zip`, should be put in this directory.
 
 To compile the debug version of these plugins, type "make BITS=32" for the 32-bits version,


### PR DESCRIPTION
the old link was dead since vegas changed their website. i've replaced it with an up-to-date one.